### PR TITLE
change js class name of layer-group-toggle

### DIFF
--- a/addon/components/labs-ui/accordion-menu.js
+++ b/addon/components/labs-ui/accordion-menu.js
@@ -11,16 +11,16 @@ export default class AccordionMenuComponent extends Component {
   constructor(...args) {
     super(...args);
 
-    this.set('layerMenuItems', A([]));
+    this.set('layerGroupToggleItems', A([]));
   }
 
   layout = layout;
 
   classNames=['accordion-menu'];
 
-  @computed('layerMenuItems.@each.active')
+  @computed('layerGroupToggleItems.@each.active')
   get numberMenuItems() {
-    const items = this.get('layerMenuItems');
+    const items = this.get('layerGroupToggleItems');
 
     const activeStates = items.mapBy('active');
 
@@ -53,14 +53,14 @@ export default class AccordionMenuComponent extends Component {
   @action
   registerChild(componentContext) {
     next(() => {
-      this.get('layerMenuItems').pushObject(componentContext);
+      this.get('layerGroupToggleItems').pushObject(componentContext);
     });
   }
 
   @action
   unregisterChild(componentContext) {
     next(() => {
-      this.get('layerMenuItems').removeObject(componentContext);
+      this.get('layerGroupToggleItems').removeObject(componentContext);
     });
   }
 }

--- a/addon/components/labs-ui/layer-group-toggle.js
+++ b/addon/components/labs-ui/layer-group-toggle.js
@@ -7,7 +7,7 @@ import { classNames } from '@ember-decorators/component';
 import layout from '../../templates/components/labs-ui/layer-group-toggle';
 
 @classNames('layer-group-toggle')
-export default class LabsUILayerMenuItemComponent extends Component {
+export default class LabsUILayerGroupToggleComponent extends Component {
   constructor(...args) {
     super(...args);
     this.get('didInit')(this);


### PR DESCRIPTION
The Layer Group Toggle component was previously `LabsUILayerMenuItemComponent` (which wasn't semantic). This PR changes the JS class to `LabsUILayerGroupToggleComponent`. 

It also makes a semantic change to the `numberMenuItems` computed property on the Accordion Menu component (I assume this isn't a breaking change because the property isn't being used in the handlebars). 