### PR TITLE
Site header z-index

### DIFF
--- a/app/styles/labs-ui/modules/_m-site-header.scss
+++ b/app/styles/labs-ui/modules/_m-site-header.scss
@@ -26,6 +26,8 @@ $logo-height-medium: rem-calc(36);
 .site-header {
   background-color: $white;
   box-shadow: 0 4px 0 rgba(0,0,0,0.1);
+  position: relative;
+  z-index: 2;
 
   .branding {
     padding-top: $global-margin;


### PR DESCRIPTION
This PR adds `z-index` to `site-header` component so it stacks above the other content. Its shadow wasn't visible, and if it included a dropdown menu on large screens, the items would've been covered by the main content. 