### PR TITLE
don't preventDefault on site-header actions

### DIFF
--- a/addon/templates/components/labs-ui/site-header.hbs
+++ b/addon/templates/components/labs-ui/site-header.hbs
@@ -2,7 +2,7 @@
   <a href="https://planninglabs.nyc/" class="labs-beta-notice hide-for-print">A beta project of NYC Planning Labs</a>
   <div class="grid-x grid-padding-x">
 
-    <div {{action (mut closed) true}} class="branding cell {{if responsiveNav (concat responsiveSize '-auto shrink') 'auto'}}">
+    <div {{action (mut closed) true preventDefault=false}} class="branding cell {{if responsiveNav (concat responsiveSize '-auto shrink') 'auto'}}">
       <a class="dcp-link" href="http://www1.nyc.gov/site/planning/index.page"><img class="dcp-logo" src="https://raw.githubusercontent.com/NYCPlanning/logo/master/dcp_logo_772.png" alt="NYC Planning"></a>
       {{yield (hash title = (component 'labs-ui/site-title'))}}
     </div>
@@ -13,7 +13,7 @@
       </div>
     {{/if}}
 
-    <nav {{action (mut closed) (not closed)}} role="navigation" class="cell {{if responsiveNav (concat responsiveSize '-shrink responsive') 'shrink'}} {{if (and responsiveNav closed) (concat 'show-for-' responsiveSize)}} hide-for-print">
+    <nav {{action (mut closed) (not closed) preventDefault=false}} role="navigation" class="cell {{if responsiveNav (concat responsiveSize '-shrink responsive') 'shrink'}} {{if (and responsiveNav closed) (concat 'show-for-' responsiveSize)}} hide-for-print">
       {{yield (hash nav = (component 'labs-ui/site-nav'))}}
     </nav>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -174,9 +174,9 @@ as |banner|
 &#123;{/banner.title}}
 &#123;{#banner.nav}}
   &lt;ul class="menu vertical medium-horizontal">
-    &lt;li>&lt;a>One&lt;/a>&lt;/li>
-    &lt;li>&lt;a>Two&lt;/a>&lt;/li>
-    &lt;li>&lt;a>Three&lt;/a>&lt;/li>
+    &lt;li>&#123;{link-to 'One' 'index'}}&lt;/li>
+    &lt;li>&#123;{link-to 'Two' 'index'}}&lt;/li>
+    &lt;li class="external-nav-item">&lt;a href="mailto:email@example.org">Mailto Link&lt;/a>&lt;/li>
   &lt;/ul>
 &#123;{/banner.nav}}
 &#123;{/labs-ui/site-header}}</code></pre>
@@ -190,8 +190,9 @@ as |banner|
         {{/banner.title}}
         {{#banner.nav}}
           <ul class="menu vertical medium-horizontal">
-            <li><a>One</a></li>
-            <li><a>Two</a></li>
+            <li>{{link-to 'One' 'index'}}</li>
+            <li>{{link-to 'Two' 'index'}}</li>
+            <li class="external-nav-item"><a href="mailto:email@example.org">Email</a></li>
           </ul>
         {{/banner.nav}}
       {{/labs-ui/site-header}}


### PR DESCRIPTION
This PR adds `preventDefault=false` to the actions in the Site Header grid which were preventing regular links from working (see https://github.com/NYCPlanning/labs-factfinder/issues/661). 

Closes #44.
