### PR TITLE
revert dummy app from decorators to default syntax

### DIFF
--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+import fetch from 'fetch';
+import config from '../config/environment';
+
+const { host } = config;
+
+export default DS.JSONAPIAdapter.extend({
+  host: host,
+
+   async query(store, type) {
+    const URL = `${this.buildURL(type.modelName)}.json`;
+     return fetch(`${URL}`, {
+      method: 'GET',
+    }).then(blob => blob.json());
+  }
+});

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/routes/sample-map.js
+++ b/tests/dummy/app/routes/sample-map.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});


### PR DESCRIPTION
Fixes the docs which broke in the previous PR. Closes #43. 