### PR TITLE
numberMenuItems + active LG classes

### DIFF
--- a/addon/components/labs-ui/layer-group-toggle.js
+++ b/addon/components/labs-ui/layer-group-toggle.js
@@ -11,6 +11,7 @@ export default Component.extend({
   },
 
   classNames: ['layer-group-toggle'],
+  classNameBindings: ['active'],
 
   layout,
 

--- a/addon/components/labs-ui/layer-groups-container.js
+++ b/addon/components/labs-ui/layer-groups-container.js
@@ -14,6 +14,7 @@ export default Component.extend({
   layout,
 
   classNames: ['layer-groups-container'],
+  classNameBindings: ['open'],
 
   numberMenuItems: computed('layerGroupToggleItems.@each.active', function() {
     const items = this.get('layerGroupToggleItems');
@@ -52,4 +53,3 @@ export default Component.extend({
     },
   },
 });
-

--- a/addon/templates/components/labs-ui/layer-groups-container.hbs
+++ b/addon/templates/components/labs-ui/layer-groups-container.hbs
@@ -2,15 +2,16 @@
   class="layer-groups-container-title {{unless open 'closed'}} layer-groups-container--{{dasherize title}}"
   role="button">
   {{title}}
+  {{#if numberMenuItems}}
+    <span class="badge">{{numberMenuItems}}</span>
+  {{/if}}
   {{#if (and mapIsLoading open numberMenuItems)}}
     {{fa-icon 'spinner' class='fa-spin medium-gray'}}
   {{/if}}
 </div>
-{{#if open}}
-  <div class="layer-groups-container-content">
-    {{yield (hash
-        layer-group-toggle=(component 'labs-ui/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
-      )
-    }}
-  </div>
-{{/if}}
+<div class="layer-groups-container-content">
+  {{yield (hash
+      layer-group-toggle=(component 'labs-ui/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
+    )
+  }}
+</div>

--- a/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
+++ b/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
@@ -3,13 +3,17 @@
 // --------------------------------------------------
 
 //
-// Layer Group Toggle
+// Layer Group Container
 // --------------------------------------------------
 .layer-groups-container {
   border-bottom: 1px solid $silver;
 
   &:hover {
     background-color: rgba(107,113,123,.06);
+  }
+
+  &:not(.open) .layer-groups-container-content {
+    display: none;
   }
 }
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -328,6 +328,7 @@ yielded content goes here
   <div class="grid-x grid-margin-x">
     <div class="cell large-5">
       <p>A group of layer groups&hellip; <em>Set of groups?</em> A toggleable container, this component is always used in block form. Its <code>title</code> param renders a clickable title which toggles the visibility of its yielded content. When its title is clicked, the <code>open</code> boolean is reversed and the visibility of the component's yielded content is toggled.</p>
+      <p>For full functionality, use Layer Group Toggles as <a href="https://embermap.com/topics/contextual-components/flexible-interfaces">contextual components</a>.</p>
       <table>
         <thead>
           <tr>
@@ -352,20 +353,23 @@ yielded content goes here
           </tr>
         </tbody>
       </table>
-      <p class="text-small"><em>Note:</em> Since the yielded content can be anything, its layout is unopinionated (e.g. it needs its own padding to align text with the title text).</p>
     </div>
     <div class="cell large-7">
       <pre><code>&#123;{#labs-ui/layer-groups-container
-title='Layer Groups Container Title'
-active=true
+  title='Layer Groups Container Title'
+  active=true
+  as |container|
 }}
-yielded content goes here
+  &#123;{container.layer-group-toggle label='Layer Group One' active=true}}
+  &#123;{container.layer-group-toggle label='Layer Group Two' active=false}}
 &#123;{/labs-ui/layer-groups-container}}</code></pre>
       {{#labs-ui/layer-groups-container
         title='Layer Groups Container Title'
         open=true
+        as |container|
       }}
-      yielded content goes here
+        {{container.layer-group-toggle label='Layer Group One' active=true}}
+        {{container.layer-group-toggle label='Layer Group Two' active=false}}
       {{/labs-ui/layer-groups-container}}
     </div>
   </div>


### PR DESCRIPTION
This PR closes #14 by… 
- Adding `active` and `open` classes to Layer Group Toggle and Layer Group Container components 
- Fixing and documenting the `numberMenuItems` badge in the Layer Group Container component