### PR TITLE
737 legend info link

### DIFF
--- a/addon/components/labs-ui/layer-group-toggle.js
+++ b/addon/components/labs-ui/layer-group-toggle.js
@@ -18,6 +18,10 @@ export default Component.extend({
 
   tooltip: '',
 
+  infoLink: '',
+
+  infoLinkIcon: 'link',
+
   tooltipIcon: 'info-circle',
 
   active: true,

--- a/addon/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/addon/templates/components/labs-ui/layer-group-toggle.hbs
@@ -6,6 +6,7 @@
     </label>
   </div>
   <span {{action 'toggle'}} class="layer-group-toggle-label" role="button">
+
     {{#if tooltip}}
       {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left'}}
     {{/if}}
@@ -15,6 +16,12 @@
     {{/if}}
 
     {{label}}
+
+    {{#if active}}
+      {{#if infoLink}}
+        <span class="info-link"><a href="{{infoLink}}" target="_blank">{{fa-icon infoLinkIcon}}</a></span>
+      {{/if}}
+    {{/if}}
 
     {{#if active}}
       {{#if icon}}

--- a/addon/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/addon/templates/components/labs-ui/layer-group-toggle.hbs
@@ -5,7 +5,7 @@
       <span class="show-for-sr">Toggle Layer Group</span>
     </label>
   </div>
-  <span {{action 'toggle'}} class="layer-group-toggle-label" role="button">
+  <span {{action 'toggle' preventDefault=false}} class="layer-group-toggle-label" role="button">
 
     {{#if tooltip}}
       {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left'}}

--- a/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
+++ b/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
@@ -44,7 +44,6 @@
 .layer-group-toggle {
   border-top: 1px solid $white;
   font-size: rem-calc(12);
-  z-index: 100;
 }
 
 .layer-group-toggle-header {
@@ -78,7 +77,6 @@
 }
 
 .info-link {
-  z-index: 500;
   float: right;
 }
 

--- a/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
+++ b/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
@@ -44,6 +44,7 @@
 .layer-group-toggle {
   border-top: 1px solid $white;
   font-size: rem-calc(12);
+  z-index: 100;
 }
 
 .layer-group-toggle-header {
@@ -74,6 +75,11 @@
       left: 0.625rem;
     }
   }
+}
+
+.info-link {
+  z-index: 500;
+  float: right;
 }
 
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -82,9 +82,7 @@ in the middle of some text.
     </div>
   </div>
 
-
   <hr />
-
 
   <h3 class="no-margin subsection-header" data-anchor="ember-tooltips">
     Ember Tooltips
@@ -306,6 +304,7 @@ yielded content goes here
       {{#labs-ui/layer-group-toggle
         label='Layer Group Label'
         active=false
+        infoLink='https://planninglabs.nyc/'
         tooltip='I show up regardless of the active state.'
         tooltipIcon='tree'
         activeTooltip="I only show up when the layer group is active."


### PR DESCRIPTION
This PR adds `infoLink` and `infoLinkIcon` properties to `layer-group-toggle` component. These icons are meant to go in the legend in zola for supporting layers that do not have their own profiles. 
These icons link out to an information page for the associated supporting layers. Now in the zola frontend we will set `infoLink` equal to  `layerGroups.layer-name.legend.infoLink` in layer-group-toggle.

The infoLink icon will only show up when the layer is toggled on (`active`)