### PR TITLE
742 fix legend icons

### DIFF
--- a/addon/components/labs-ui/icons/fa-icon.js
+++ b/addon/components/labs-ui/icons/fa-icon.js
@@ -11,6 +11,8 @@ export default Component.extend({
   classNames: ['legend-icon-layer'],
   layout,
 
+  options() {},
+
   spanStyle: computed('options.color', function() {
     return htmlSafe(this.options.color ? `color: ${this.options.color}` : '');
   }),

--- a/addon/components/labs-ui/icons/fa-icon.js
+++ b/addon/components/labs-ui/icons/fa-icon.js
@@ -6,8 +6,6 @@ import layout from '../../../templates/components/labs-ui/icons/fa-icon';
 export default Component.extend({
   init() {
     this._super(...arguments);
-
-    this.set('options', {});
   },
   tagName: 'span',
   classNames: ['legend-icon-layer'],

--- a/addon/components/labs-ui/icons/line.js
+++ b/addon/components/labs-ui/icons/line.js
@@ -5,8 +5,6 @@ import layout from '../../../templates/components/labs-ui/icons/line';
 export default Component.extend({
   init() {
     this._super(...arguments);
-
-    this.set('options', {});
   },
 
   classNames: ['legend-icon-layer', 'line'],
@@ -17,7 +15,7 @@ export default Component.extend({
     const defaultOptions = {
       stroke: 'SteelBlue'
     };
-    const options = this.get('options');
+    const options = this.get('options'); // options should be an object
 
     return Object.assign(defaultOptions, options);
   }),

--- a/addon/components/labs-ui/icons/rectangle.js
+++ b/addon/components/labs-ui/icons/rectangle.js
@@ -5,8 +5,6 @@ import layout from '../../../templates/components/labs-ui/icons/rectangle';
 export default Component.extend({
   init() {
     this._super(...arguments);
-
-    this.set('options', {});
   },
 
   tagName: 'svg',
@@ -20,7 +18,7 @@ export default Component.extend({
       fill: 'rgba(70, 130, 180, 0.5)',
       'stroke-linejoin': 'round',
     };
-    const options = this.get('options');
+    const options = this.get('options'); // options should be an object
 
     return Object.assign(defaultOptions, options);
   }),

--- a/addon/templates/components/labs-ui/layer-groups-container.hbs
+++ b/addon/templates/components/labs-ui/layer-groups-container.hbs
@@ -9,9 +9,11 @@
     {{fa-icon 'spinner' class='fa-spin medium-gray'}}
   {{/if}}
 </div>
-<div class="layer-groups-container-content">
-  {{yield (hash
-      layer-group-toggle=(component 'labs-ui/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
-    )
-  }}
-</div>
+{{#if open}}
+  <div class="layer-groups-container-content">
+    {{yield (hash
+        layer-group-toggle=(component 'labs-ui/layer-group-toggle' willDestroyHook=(action 'unregisterChild') didInit=(action 'registerChild'))
+      )
+    }}
+  </div>
+{{/if}}


### PR DESCRIPTION
This PR removes `this.set('options', {})` from the init in the icon components to avoid overriding `options` throughout the rest of the code with an empty object. This was making the legend icons in zola show up as the default color (blue). 

This PR also fixes `layer-group-container-test` by adding back the conditional `{{#if open}}` to `layer-group-container` handlebars, which had been removed in previous commits. 