### PR TITLE
Fix legend tooltip spacing and behavior

### DIFF
--- a/addon/components/labs-ui/icon-tooltip.js
+++ b/addon/components/labs-ui/icon-tooltip.js
@@ -10,4 +10,5 @@ export default Component.extend({
   side: 'top',
   icon: 'info-circle',
   transform: '',
+  fixedWidth: false,
 });

--- a/addon/components/labs-ui/layer-group-toggle.js
+++ b/addon/components/labs-ui/layer-group-toggle.js
@@ -21,7 +21,7 @@ export default Component.extend({
 
   infoLink: '',
 
-  infoLinkIcon: 'link',
+  infoLinkIcon: 'external-link-alt',
 
   tooltipIcon: 'info-circle',
 

--- a/addon/templates/components/labs-ui/icon-tooltip.hbs
+++ b/addon/templates/components/labs-ui/icon-tooltip.hbs
@@ -1,2 +1,2 @@
-{{~fa-icon icon=icon transform=transform fixedWidth=true~}}
+{{~fa-icon icon=icon transform=transform fixedWidth=fixedWidth~}}
 {{ember-tooltip text=tip side=side}}

--- a/addon/templates/components/labs-ui/icon-tooltip.hbs
+++ b/addon/templates/components/labs-ui/icon-tooltip.hbs
@@ -1,2 +1,2 @@
-{{~fa-icon icon=icon transform=transform ~}}
+{{~fa-icon icon=icon transform=transform fixedWidth=true~}}
 {{ember-tooltip text=tip side=side}}

--- a/addon/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/addon/templates/components/labs-ui/layer-group-toggle.hbs
@@ -10,12 +10,10 @@
     {{#if tooltip}}
       {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left'}}
     {{/if}}
-    
-    {{#if active}}
+
      {{#if infoLink}}
        <span class="info-link"><a href="{{infoLink}}" target="_blank">{{fa-icon infoLinkIcon}}</a></span>
      {{/if}}
-    {{/if}}
 
     {{#if (and activeTooltip active)}}
       {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left'}}

--- a/addon/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/addon/templates/components/labs-ui/layer-group-toggle.hbs
@@ -1,33 +1,33 @@
 <div class="layer-group-toggle-header layer-{{dasherize label}}">
-  <div class="switch tiny float-left">
-    <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-    <label {{action 'toggle'}} class="switch-paddle">
-      <span class="show-for-sr">Toggle Layer Group</span>
-    </label>
-  </div>
-  <span {{action 'toggle' preventDefault=false}} class="layer-group-toggle-label" role="button">
-
-    {{#if tooltip}}
-      {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left'}}
-    {{/if}}
-
-     {{#if infoLink}}
-       <span class="info-link"><a href="{{infoLink}}" target="_blank">{{fa-icon infoLinkIcon}}</a></span>
-     {{/if}}
-
-    {{#if (and activeTooltip active)}}
-      {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left'}}
-    {{/if}}
-
-    {{label}}
-
-    {{#if active}}
-      {{#if icon}}
-        {{labs-ui/legend-icon icon=icon}}
+  <div class="grid-x">
+    <div class="cell auto ">
+      <div class="switch tiny float-left">
+        <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
+        <label {{action 'toggle'}} class="switch-paddle">
+          <span class="show-for-sr">Toggle Layer Group</span>
+        </label>
+      </div>
+      <span {{action 'toggle' preventDefault=false}} class="layer-group-toggle-label" role="button">
+        {{label}}
+        {{#if active}}
+          {{#if icon}}
+            {{labs-ui/legend-icon icon=icon}}
+          {{/if}}
+        {{/if}}
+      </span>
+    </div>
+    <div class="cell shrink layer-group-toggle-icons">
+      {{#if tooltip}}
+        {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
       {{/if}}
-    {{/if}}
-
-  </span>
+      {{#if infoLink}}
+        <a href="{{infoLink}}" target="_blank" class="info-link">{{fa-icon infoLinkIcon fixedWidth=true}}</a>
+      {{/if}}
+      {{#if (and activeTooltip active)}}
+        {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
+      {{/if}}
+    </div>
+  </div>
 </div>
 {{#if active}}
   <div class="layer-group-toggle-content">

--- a/addon/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/addon/templates/components/labs-ui/layer-group-toggle.hbs
@@ -17,14 +17,14 @@
       </span>
     </div>
     <div class="cell shrink layer-group-toggle-icons">
-      {{#if tooltip}}
-        {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
+      {{#if (and activeTooltip active)}}
+        {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
       {{/if}}
       {{#if infoLink}}
         <a href="{{infoLink}}" target="_blank" class="info-link">{{fa-icon infoLinkIcon fixedWidth=true}}</a>
       {{/if}}
-      {{#if (and activeTooltip active)}}
-        {{labs-ui/icon-tooltip tip=activeTooltip icon=activeTooltipIcon side='left' fixedWith=true}}
+      {{#if tooltip}}
+        {{labs-ui/icon-tooltip tip=tooltip icon=tooltipIcon side='left' fixedWidth=true}}
       {{/if}}
     </div>
   </div>

--- a/addon/templates/components/labs-ui/legend-item.hbs
+++ b/addon/templates/components/labs-ui/legend-item.hbs
@@ -1,7 +1,11 @@
-{{labs-ui/legend-icon icon=item.icon}}
-
-{{#if item.tooltip}}
-  {{labs-ui/icon-tooltip tip=item.tooltip side='left'}}
-{{/if}}
-
-{{item.label}}
+<div class="grid-x">
+  <div class="cell auto">
+    {{labs-ui/legend-icon icon=item.icon}}
+    {{item.label}}
+  </div>
+  <div class="cell shrink">
+    {{#if item.tooltip}}
+      {{labs-ui/icon-tooltip tip=item.tooltip side='left' fixedWidth=true}}
+    {{/if}}
+  </div>
+</div>

--- a/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
+++ b/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
@@ -15,6 +15,14 @@
   &:not(.open) .layer-groups-container-content {
     display: none;
   }
+
+  .fa-info-circle {
+    color: $blue-dark;
+  }
+
+  .fa-exclamation-triangle {
+    color: $orange;
+  }
 }
 
 .layer-groups-container-title {
@@ -157,31 +165,5 @@ svg.legend-icon-layer {
   .dash {
     border-width: 2px;
     border-style: dotted;
-  }
-}
-
-
-//
-// Tooltips
-// --------------------------------------------------
-.layer-group-toggle-label,
-.legend-item {
-
-  .icon-tooltip {
-    float: right;
-    margin-right: rem-calc(3);
-    margin-left: rem-calc(6);
-  }
-
-  .icon-tooltip + .icon-tooltip {
-    margin-right: 0;
-  }
-
-  .fa-info-circle {
-    color: $blue-dark;
-  }
-
-  .fa-exclamation-triangle {
-    color: $orange;
   }
 }

--- a/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
+++ b/app/styles/labs-ui/modules/_m-layer-groups-menu.scss
@@ -54,6 +54,9 @@
 
   &:hover {
     background-color: rgba(107,113,123,.06);
+  }
+
+  .cell:first-child:hover {
     cursor: pointer;
   }
 
@@ -78,10 +81,10 @@
       left: 0.625rem;
     }
   }
-}
 
-.info-link {
-  float: right;
+  .layer-group-toggle-icons {
+    padding: rem-calc(6);
+  }
 }
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,9 +3519,9 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-fetch@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-4.0.1.tgz#0d43517c5e26de7ebd0777c983d675e79ecb40ad"
+ember-fetch@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-4.0.2.tgz#865ca90d8aa63b9ebe5bce709aeaa44b35668b5a"
   dependencies:
     abortcontroller-polyfill "^1.1.9"
     broccoli-concat "^3.2.2"
@@ -3532,15 +3532,16 @@ ember-fetch@4.0.1:
     node-fetch "^2.0.0-alpha.9"
     yetch "^0.0.1"
 
-ember-fetch@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-4.0.2.tgz#865ca90d8aa63b9ebe5bce709aeaa44b35668b5a"
+ember-fetch@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-5.0.0.tgz#fc58980010d625e9d86d238cbaabe7803fdddcfa"
+  integrity sha1-/FiYABDWJenYbSOMuqvngD/d3Po=
   dependencies:
     abortcontroller-polyfill "^1.1.9"
     broccoli-concat "^3.2.2"
     broccoli-merge-trees "^2.0.0"
     broccoli-stew "^1.4.2"
-    broccoli-templater "^1.0.0"
+    broccoli-templater "^2.0.1"
     ember-cli-babel "^6.8.2"
     node-fetch "^2.0.0-alpha.9"
     yetch "^0.0.1"


### PR DESCRIPTION
This PR fixes spacing of tooltips on the legend. It also makes it so that `infolink` icon shows up when layer is toggled ON or OFF. 