### PR TITLE
71:  Pin @fortawesome/free-solid-svg-icons to 5.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,6 @@ https://ui.planninglabs.nyc/
 
 ##### A) Requirements:
 
-Install the NYC Digital Style Guide.
-```
-yarn add nyc-planning-style-guide
-```
-
-Install the Sass compiler and make sure you have an `app.scss` file.
-```
-ember install ember-cli-sass
-```
-
 Install Ember Truth Helpers.
 ```
 ember install ember-truth-helpers
@@ -96,9 +86,6 @@ Import the required files and include mixins in the right order so consuming app
 
 ```
 ember install @fortawesome/ember-fontawesome
-yarn add --dev @fortawesome/free-solid-svg-icons
-yarn add --dev @fortawesome/free-regular-svg-icons
-yarn add --dev @fortawesome/free-brands-svg-icons
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labs-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NYC Planning Labs Ember.js Components",
   "keywords": [
     "ember-addon"
@@ -27,7 +27,7 @@
     "@fortawesome/ember-fontawesome": ">=0.2.1",
     "@fortawesome/free-brands-svg-icons": ">=5.2.0",
     "@fortawesome/free-regular-svg-icons": ">=5.1.0",
-    "@fortawesome/free-solid-svg-icons": ">=5.1.0",
+    "@fortawesome/free-solid-svg-icons": "5.12.0",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-htmlbars": "^4.2.3",
     "ember-cli-sass": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@
     glob "^7.1.2"
     rollup-plugin-node-resolve "^5.2.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.28":
+"@fortawesome/fontawesome-common-types@^0.2.26", "@fortawesome/fontawesome-common-types@^0.2.28":
   version "0.2.28"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz#1091bdfe63b3f139441e9cba27aa022bff97d8b2"
   integrity sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg==
@@ -1112,12 +1112,12 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.28"
 
-"@fortawesome/free-solid-svg-icons@>=5.1.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz#44d9118668ad96b4fd5c9434a43efc5903525739"
-  integrity sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==
+"@fortawesome/free-solid-svg-icons@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.0.tgz#8decac5844e60453cc0c7c51437d1461df053a35"
+  integrity sha512-CnpsWs6GhTs9ekNB3d8rcO5HYqRkXbYKf2YNiAlTWbj5eVlPqsd/XH1F9If8jkcR1aegryAbln/qYeKVZzpM0g==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.28"
+    "@fortawesome/fontawesome-common-types" "^0.2.26"
 
 "@glimmer/compiler@^0.27.0":
   version "0.27.0"
@@ -4813,14 +4813,6 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
-
-ember-cli-github-pages@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-github-pages/-/ember-cli-github-pages-0.2.2.tgz#cef01ed1de9ddd82863b310fef05e7f5b55beb9e"
-  integrity sha512-pFtruVBZ5OW1O1MiGQRQSQewW9DSBx6ZbRcbVpcpTlZqeDyWs5nyvhOm4qRFwK6m+jQPe2l52cYtf1rUAkBNxA==
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    rsvp "^4.7.0"
 
 ember-cli-htmlbars-inline-precompile@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Addresses #71

<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR pins @fortawesome/free-solid-svg-icons to 5.12 to fix bug, updates developer documentation to depend on yarn dependency resolution rather than instructing users to manually install a copy of the fortawesome packages (it's a dependency in labs-ui, so will be installed for users when they install labs-ui).

For some reason was having issues relying on the dependency `ember-truth-helpers`, so kept that in the developer setup documentation.

Changes Proposed:
- Bug fix
- Bump to v1.0.1
- README update

Closes #71

- [x ] Documentation has been created/updated to reflect changes in this PR
- [ ] Tests have been written to prevent regressions or breaking changes
